### PR TITLE
Simplify regexp to find ruby tags

### DIFF
--- a/lib/html/pipeline/ruby_markup/transformer.rb
+++ b/lib/html/pipeline/ruby_markup/transformer.rb
@@ -25,10 +25,10 @@ module HTML
         RubyTagPattern = %r(
           (?<!!)
           \[
-            (?<word>[^\[\(\)]+(?=\())(?<!\s)
-            \((?<reading>[^\[\]]+(?=\)))\)
+            (?<word>[^\[\(]+(?=\())(?<!\s)
+            \((?<reading>[^\)]+(?=\)))\)
           \]
-          (\((?<uri>[^\(\)]+(?=\)))\))*
+          (\((?<uri>[^\)]+(?=\)))\))*
         )x
         RubyMarkupInsideCodePattern = /`.*#{RubyTagPattern}.*`/
 


### PR DESCRIPTION
```
$ rake

HTML::Pipeline::RubyMarkup::Filter
  does mistake treat image inside link as ruby markup
  works when annotates and links separately
  works when annotates two characters separately but links together
  does not translate ruby markup inside code block
  does not translate wrong ruby markup syntax (no space before left paren)
  works when annotates two characters separately
  works with markdown link syntax
  does not translate ruby markup inside code
  works with markdown link
  translate ruby markup outside the code block
  does not translate ruby markup inside code with arbitrary spaces
  translate [text(reading)] into ruby markup
  works for two ruby markups close by
  works with content has no ruby markups
  correctly translates a document uses ruby heavily
  does not translate ruby markup inside code block with arbitrary text around

Finished in 0.01308 seconds (files took 0.2603 seconds to load)
16 examples, 0 failures
```