### PR TITLE
Handle empty content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Handle for nil or empty content input [#2] by @JuanitoFatas
+
+[#2]: https://github.com/JuanitoFatas/html-pipeline-ruby_markup/pull/2
+
 ## 0.9.1
 
 Simplify Regexp [#1] by @JuanitoFatas

--- a/lib/html/pipeline/ruby_markup.rb
+++ b/lib/html/pipeline/ruby_markup.rb
@@ -8,7 +8,7 @@ module HTML
     module RubyMarkup
       class Filter < HTML::Pipeline::TextFilter
         def call
-          Transformer.run(text.dup)
+          Transformer.run(text.dup.to_s)
         end
       end
     end

--- a/lib/html/pipeline/ruby_markup/transformer.rb
+++ b/lib/html/pipeline/ruby_markup/transformer.rb
@@ -35,7 +35,7 @@ module HTML
         attr_reader :content
 
         def traverser
-          @traverser ||= MarkdownTraverser.new(content)
+          @traverser ||= content.empty? ? [] : MarkdownTraverser.new(content)
         end
 
         def transform_ruby_markups!

--- a/spec/ruby_markup_spec.rb
+++ b/spec/ruby_markup_spec.rb
@@ -6,6 +6,22 @@ require "html/pipeline/ruby_markup"
 RubyMarkup = HTML::Pipeline::RubyMarkup
 
 RSpec.describe RubyMarkup::Filter do
+  it "not error out with nil content" do
+    input = nil
+
+    result = RubyMarkup::Filter.new(input).call
+
+    expect(result).to eq ""
+  end
+
+  it "not error out with empty content" do
+    input = ""
+
+    result = RubyMarkup::Filter.new(input).call
+
+    expect(result).to eq ""
+  end
+
   it "works with content has no ruby markups" do
     input = "markdown"
 


### PR DESCRIPTION
Should not even instantiate `MarkdownTraverser` given nil or "".